### PR TITLE
Make record section plotting more convenient

### DIFF
--- a/examples/section_example.py
+++ b/examples/section_example.py
@@ -5,4 +5,9 @@ st = Stream.from_iris(
 )
 st.detrend('demean').taper(0.05).remove_response(output='DISP')
 st.taper(0.05).filter('highpass', freq=2)
-st.plot(src_lat=37.26842, src_lon=-112.93468, reftime=(2023, 11, 14, 22, 38, 42))
+st.plot(
+    src_lat=37.26842,
+    src_lon=-112.93468,
+    reftime=(2023, 11, 14, 22, 38, 42),
+    wavespeed=2.6,  # [km/s]
+)

--- a/examples/section_example.py
+++ b/examples/section_example.py
@@ -1,0 +1,8 @@
+from saul import Stream
+
+st = Stream.from_iris(
+    'UU', 'ZNPU,KNB,LCMT', 'HHN', (2023, 11, 14, 22, 38), (2023, 11, 14, 22, 40)
+)
+st.detrend('demean').taper(0.05).remove_response(output='DISP')
+st.taper(0.05).filter('highpass', freq=2)
+st.plot(src_lat=37.26842, src_lon=-112.93468, reftime=(2023, 11, 14, 22, 38, 42))

--- a/saul/waveform/stream.py
+++ b/saul/waveform/stream.py
@@ -158,13 +158,24 @@ class Stream(obspy.Stream):
                     transform=transform,
                 )
             if wavespeed is not None:
+                color = 'tab:red'
                 ymax = ax.get_ylim()[1]  # [km]
                 ax.plot(
                     [0, ymax / wavespeed],
                     [0, ymax],
-                    color='tab:red',
+                    color=color,
                     scalex=False,
                     scaley=False,
+                )
+                transform = blended_transform_factory(ax.transData, ax.transAxes)
+                ax.text(
+                    ymax / wavespeed,
+                    1.02,
+                    f'{wavespeed} km/s',
+                    color=color,
+                    transform=transform,
+                    ha='center',
+                    va='baseline',
                 )
             reftime = kwargs.get('reftime', min([tr.stats.starttime for tr in st_plot]))
             time_format = '%Y-%m-%d %H:%M:%S'

--- a/saul/waveform/stream.py
+++ b/saul/waveform/stream.py
@@ -112,6 +112,8 @@ class Stream(obspy.Stream):
             Can obtain standard :meth:`obspy.core.stream.Stream.plot` behavior by
             setting ``fig=None``.
         """
+        if 'reftime' in kwargs:
+            kwargs['reftime'] = self._preprocess_time(kwargs['reftime'])  # Allow tuples
         if 'fig' not in kwargs:
             from matplotlib.pyplot import figure
 

--- a/saul/waveform/stream.py
+++ b/saul/waveform/stream.py
@@ -120,12 +120,14 @@ class Stream(obspy.Stream):
             kwargs['fig'] = figure()
         if 'src_lat' in kwargs and 'src_lon' in kwargs:
             kwargs['type'] = 'section'
-            for kwarg in 'orientation', 'outfile', 'format', 'handle':
+            for kwarg in 'orientation', 'outfile', 'format', 'handle', 'vred':
                 if kwarg in kwargs:
                     print(f'Ignoring `{kwarg}` kwarg!')  # Since we set these below
             kwargs['orientation'] = 'horizontal'
-            kwargs['outfile'], kwargs['format'] = None, None  # Disable these!
+            kwargs['outfile'] = None  # Disable
+            kwargs['format'] = None  # Disable
             kwargs['handle'] = True  # Ensures that the Figure instance is returned
+            kwargs['vred'] = None  # Disable, https://github.com/obspy/obspy/issues/3371
             if 'alpha' not in kwargs:
                 kwargs['alpha'] = 1
             src_lat, src_lon = kwargs.pop('src_lat'), kwargs.pop('src_lon')


### PR DESCRIPTION
Automatically calculates the source–receiver distances so that the user just needs to specify a (`src_lat`, `src_lon`)