### PR TITLE
Add functionality to compute and plot filter responses

### DIFF
--- a/examples/filter_response_example.py
+++ b/examples/filter_response_example.py
@@ -7,7 +7,7 @@ tr = read()[0]
 tr.detrend('demean').taper(0.05).remove_sensitivity()
 
 filter_type = 'bandpass'
-options = dict(freqmin=1, freqmax=5, zerophase=False, corners=4)
+options = dict(freqmin=1, freqmax=5, zerophase=False, corners=8)
 trf = tr.copy().filter(filter_type, **options)
 
 psd = PSD([tr, trf], win_dur=20)

--- a/examples/filter_response_example.py
+++ b/examples/filter_response_example.py
@@ -1,0 +1,32 @@
+import matplotlib.pyplot as plt
+from obspy import read
+
+from saul import PSD, obspy_filter_response
+
+tr = read()[0]
+tr.detrend('demean').taper(0.05).remove_sensitivity()
+
+filter_type = 'bandpass'
+options = dict(freqmin=1, freqmax=5, zerophase=False, corners=4)
+trf = tr.copy().filter(filter_type, **options)
+
+psd = PSD([tr, trf], win_dur=20)
+psd_max = psd.psd[1][1].max()
+f, h_db = obspy_filter_response(filter_type, tr.stats.sampling_rate, **options)
+
+psd.plot()
+fig = plt.gcf()
+ax = fig.axes[0]
+ax.axvspan(options['freqmin'], options['freqmax'], color='tab:gray', alpha=0.5, lw=0)
+ax.semilogx(f, h_db + psd_max, color='tab:gray', ls='--')
+ax.set_ylim(bottom=-200)
+ax.legend(
+    labels=[
+        'original\nsignal',
+        'filtered\nsignal',
+        'filter\npassband',
+        'filter\nresponse',
+    ],
+    loc='upper right',
+)
+fig.show()

--- a/examples/filter_response_example.py
+++ b/examples/filter_response_example.py
@@ -7,7 +7,7 @@ tr = read()[0]
 tr.detrend('demean').taper(0.05).remove_sensitivity()
 
 filter_type = 'bandpass'
-options = dict(freqmin=1, freqmax=5, zerophase=False, corners=8)
+options = dict(freqmin=1, freqmax=5, corners=8)
 trf = tr.copy().filter(filter_type, **options)
 
 psd = PSD([tr, trf], win_dur=20)

--- a/examples/filter_response_example.py
+++ b/examples/filter_response_example.py
@@ -1,23 +1,21 @@
 import matplotlib.pyplot as plt
 from obspy import read
 
-from saul import PSD, obspy_filter_response
+from saul import PSD, extract_trace_filter_params, obspy_filter_response
 
 tr = read()[0]
 tr.detrend('demean').taper(0.05).remove_sensitivity()
-
-filter_type = 'bandpass'
-options = dict(freqmin=1, freqmax=5, corners=8)
-trf = tr.copy().filter(filter_type, **options)
+freqmin, freqmax = 1, 5
+trf = tr.copy().filter('bandpass', freqmin=freqmin, freqmax=freqmax, corners=8)
 
 psd = PSD([tr, trf], win_dur=20)
 psd_max = psd.psd[1][1].max()
-f, h_db = obspy_filter_response(filter_type, tr.stats.sampling_rate, **options)
+f, h_db = obspy_filter_response(**extract_trace_filter_params(trf))
 
 psd.plot()
 fig = plt.gcf()
 ax = fig.axes[0]
-ax.axvspan(options['freqmin'], options['freqmax'], color='tab:gray', alpha=0.5, lw=0)
+ax.axvspan(freqmin, freqmax, color='tab:gray', alpha=0.5, lw=0)
 ax.semilogx(f, h_db + psd_max, color='tab:gray', ls='--')
 ax.set_ylim(bottom=-200)
 ax.legend(

--- a/saul/__init__.py
+++ b/saul/__init__.py
@@ -1,2 +1,8 @@
-from saul.spectral import PSD, Spectrogram, get_ak_infra_noise, obspy_filter_response
+from saul.spectral import (
+    PSD,
+    Spectrogram,
+    extract_trace_filter_params,
+    get_ak_infra_noise,
+    obspy_filter_response,
+)
 from saul.waveform import Stream

--- a/saul/__init__.py
+++ b/saul/__init__.py
@@ -1,2 +1,2 @@
-from saul.spectral import PSD, Spectrogram, get_ak_infra_noise
+from saul.spectral import PSD, Spectrogram, get_ak_infra_noise, obspy_filter_response
 from saul.waveform import Stream

--- a/saul/spectral/__init__.py
+++ b/saul/spectral/__init__.py
@@ -8,6 +8,6 @@ with warnings.catch_warnings():
     # Ignore "SyntaxWarning: invalid escape sequence '\ '" arising from the docstring
     # formatting in `get_ak_infra_noise()`
     warnings.simplefilter('ignore', category=SyntaxWarning)
-    from saul.spectral.helpers import get_ak_infra_noise
+    from saul.spectral.helpers import get_ak_infra_noise, obspy_filter_response
 from saul.spectral.psd import PSD
 from saul.spectral.spectrogram import Spectrogram

--- a/saul/spectral/__init__.py
+++ b/saul/spectral/__init__.py
@@ -8,6 +8,10 @@ with warnings.catch_warnings():
     # Ignore "SyntaxWarning: invalid escape sequence '\ '" arising from the docstring
     # formatting in `get_ak_infra_noise()`
     warnings.simplefilter('ignore', category=SyntaxWarning)
-    from saul.spectral.helpers import get_ak_infra_noise, obspy_filter_response
+    from saul.spectral.helpers import (
+        get_ak_infra_noise,
+        obspy_filter_response,
+        extract_trace_filter_params,
+    )
 from saul.spectral.psd import PSD
 from saul.spectral.spectrogram import Spectrogram

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -102,8 +102,11 @@ def obspy_filter_response(filter_type, sampling_rate, freqs=1024, **options):
         case _:
             raise NotImplementedError(f'Filter type "{filter_type}" is not supported.')
     f, h = freqz_zpk(z, p, k, worN=freqs, fs=df)
-    with np.errstate(divide='ignore'):
-        h_db = 20 * np.log10(abs(h))
+    # If the user didn't supply specific frequencies, we remove the DC component
+    if isinstance(freqs, (int, float)):
+        f = f[1:]
+        h = h[1:]
+    h_db = 20 * np.log10(abs(h))
     return f, h_db
 
 

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -148,6 +148,22 @@ def obspy_filter_response(
 
 
 def extract_trace_filter_params(tr):
+    """Extract filter parameters from an ObsPy :class:`~obspy.core.trace.Trace` object.
+
+    Can be combined with :func:`~saul.spectral.helpers.obspy_filter_response` to
+    conveniently plot the filter response of the last processing step.
+
+    .. code-block:: python
+
+        tr.filter(...)
+        obspy_filter_response(**extract_trace_filter_params(tr))
+
+    Args:
+        tr (:class:`~obspy.core.trace.Trace`): Input trace
+
+    Returns:
+        dict: Extracted filter parameters
+    """
     string = tr.stats.processing[-1]
     assert 'filter' in string, 'Was filtering the last processing step?'
     part_options, part_filter_type = string.rstrip(')').split('::')

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -1,5 +1,6 @@
 """
-Contains helper functions and constants for tasks related to spectral estimation.
+Contains helper functions and constants for tasks related to spectral estimation and
+filtering.
 """
 
 from pathlib import Path

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -158,7 +158,7 @@ def extract_trace_filter_params(tr):
     .. code-block:: python
 
         tr.filter(...)
-        obspy_filter_response(plot=True, **extract_trace_filter_params(tr))
+        _ = obspy_filter_response(plot=True, **extract_trace_filter_params(tr))
 
     Args:
         tr (:class:`~obspy.core.trace.Trace`): Input trace

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -56,10 +56,15 @@ def obspy_filter_response(filter_type, sampling_rate, freqs=1024, **options):
             types are supported; see the match statement in the code
         sampling_rate (int or float): Sampling rate of target data
         freqs (int or array_like): Passed on as ``worN`` argument to
-            :func:`scipy.signal.freqz_zpk`
+            :func:`scipy.signal.freqz_zpk` — if an array, the response will be computed
+            at these frequencies
         **options: Necessary keyword arguments that will be passed on to the respective
             filter function (e.g., ``freqmin=1``, ``freqmax=5`` for
             ``filter_type='bandpass'``)
+
+    Returns:
+        tuple: Array of frequencies at which the response was computed [Hz], frequency
+        response [dB]
     """
     df = sampling_rate  # Rename so that code below resembles ObsPy more closely
     match filter_type:

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -47,7 +47,20 @@ def get_ak_infra_noise():
 
 
 def obspy_filter_response(filter_type, sampling_rate, freqs=1024, **options):
-    """Based on ObsPy 1.4.1."""
+    """Calculate the frequency response of an ObsPy filter.
+
+    Based on ObsPy 1.4.1.
+
+    Args:
+        filter_type (str): Type of filter to use. Note that not all of ObsPy's filter
+            types are supported; see the match statement in the code
+        sampling_rate (int or float): Sampling rate of target data
+        freqs (int or array_like): Passed on as ``worN`` argument to
+            :func:`scipy.signal.freqz_zpk`
+        **options: Necessary keyword arguments that will be passed on to the respective
+            filter function (e.g., ``freqmin=1``, ``freqmax=5`` for
+            ``filter_type='bandpass'``)
+    """
     df = sampling_rate  # Rename so that code below resembles ObsPy more closely
     match filter_type:
         case 'bandpass':

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -50,7 +50,7 @@ def get_ak_infra_noise():
 
 
 def obspy_filter_response(
-    filter_type, sampling_rate, freqs=1024, plot=False, **options
+    filter_type, sampling_rate, freqs=4096, plot=False, **options
 ):
     """Calculate the frequency response of an ObsPy filter.
 

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -69,23 +69,14 @@ def obspy_filter_response(type, df, **options):
                 ftype='butter',
                 output='zpk',
             )
-        case 'highpass':
+        case 'highpass' | 'lowpass':
             fe = 0.5 * df
             f = options['freq'] / fe
             effective_corners = (
                 options['corners'] * 2 if options['zerophase'] else options['corners']
             )
             z, p, k = iirfilter(
-                effective_corners, f, btype='highpass', ftype='butter', output='zpk'
-            )
-        case 'lowpass':
-            fe = 0.5 * df
-            f = options['freq'] / fe
-            effective_corners = (
-                options['corners'] * 2 if options['zerophase'] else options['corners']
-            )
-            z, p, k = iirfilter(
-                effective_corners, f, btype='lowpass', ftype='butter', output='zpk'
+                effective_corners, f, btype=type, ftype='butter', output='zpk'
             )
         case 'lowpass_cheby_2':
             freq = options.pop('freq')

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -150,19 +150,25 @@ def obspy_filter_response(
 def extract_trace_filter_params(tr):
     """Extract filter parameters from an ObsPy :class:`~obspy.core.trace.Trace` object.
 
-    Can be combined with :func:`~saul.spectral.helpers.obspy_filter_response` to
-    conveniently plot the filter response of the last processing step.
+    Expects to find a filter operation in the string stored in
+    ``tr.stats.processing[-1]``. Can be combined with
+    :func:`~saul.spectral.helpers.obspy_filter_response` to conveniently plot the filter
+    response of the previous filtering operation like so:
 
     .. code-block:: python
 
         tr.filter(...)
-        obspy_filter_response(**extract_trace_filter_params(tr))
+        obspy_filter_response(plot=True, **extract_trace_filter_params(tr))
 
     Args:
         tr (:class:`~obspy.core.trace.Trace`): Input trace
 
     Returns:
         dict: Extracted filter parameters
+
+    Warning:
+        The uses sketchy string processing and :func:`eval` to extract the filter
+        parameters!
     """
     string = tr.stats.processing[-1]
     assert 'filter' in string, 'Was filtering the last processing step?'

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -147,6 +147,17 @@ def obspy_filter_response(
     return f, h_db
 
 
+def extract_trace_filter_params(tr):
+    string = tr.stats.processing[-1]
+    assert 'filter' in string, 'Was filtering the last processing step?'
+    part_options, part_filter_type = string.rstrip(')').split('::')
+    options = eval(part_options.split('=')[1])
+    filter_type = eval(part_filter_type.split('=')[1])
+    return dict(
+        filter_type=filter_type, sampling_rate=tr.stats.sampling_rate, **options
+    )
+
+
 def _get_defaults_for_filter_func(filter_type):
     """Generate dictionary of default parameters for an ObsPy filter function."""
     func = _get_function_from_entry_point('filter', filter_type)

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -84,7 +84,9 @@ def obspy_filter_response(filter_type, sampling_rate, freqs=1024, **options):
         case _:
             raise NotImplementedError(f'Filter type "{filter_type}" is not supported.')
     f, h = freqz_zpk(z, p, k, worN=freqs, fs=df)
-    return f, 20 * np.log10(abs(h))
+    with np.errstate(divide='ignore'):
+        h_db = 20 * np.log10(abs(h))
+    return f, h_db
 
 
 def _data_kind(st):


### PR DESCRIPTION
This PR adds functionality to compute and visualize filter responses for ObsPy filters. This is mainly intended to be a teaching tool. The PR adds the following two public functions:

* `extract_trace_filter_params()` — Given an input trace, searches `tr.stats.processing[-1]` to obtain the filter parameters the user provided. This allows us to plot exactly what a user's filtering choice did. Helper function.
* `obspy_filter_response()` — Actually computes, and optionally plots, the filter response for a choice of input filter parameters. Can be used standalone or with `extract_trace_filter_params()`. 
