### PR TITLE
Add deep copy method

### DIFF
--- a/saul/spectral/psd.py
+++ b/saul/spectral/psd.py
@@ -2,6 +2,7 @@
 Contains the definition of SAUL's :class:`PSD` class.
 """
 
+import copy
 from functools import cache
 
 import matplotlib.pyplot as plt
@@ -132,6 +133,10 @@ class PSD:
             worth it.
         """
         return mtspec.MTSpec(np.array(tr_data_tuple), **kwargs)
+
+    def copy(self):
+        """Return a deep copy of the :class:`PSD` object."""
+        return copy.deepcopy(self)
 
     def plot(
         self,

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -2,6 +2,7 @@
 Contains the definition of SAUL's :class:`Spectrogram` class.
 """
 
+import copy
 from functools import cache
 
 import matplotlib.dates as mdates
@@ -130,6 +131,10 @@ class Spectrogram:
             worth it.
         """
         return mtspec.spectrogram(np.array(tr_data_tuple), **kwargs)
+
+    def copy(self):
+        """Return a deep copy of the :class:`Spectrogram` object."""
+        return copy.deepcopy(self)
 
     def plot(
         self,


### PR DESCRIPTION
This small PR adds `copy()` methods to the `PSD` and `Spectrogram` classes which return a deep copy of the object. These are identical to how ObsPy's methods work for `Trace` and `Stream` objects.