### PR TITLE
Add `smooth()` method to `PSD` class

### DIFF
--- a/_doc/conf.py
+++ b/_doc/conf.py
@@ -22,6 +22,7 @@ extensions = [
 ]
 napoleon_numpy_docstring = False  # We are using Google docstring style
 autodoc_mock_imports = [
+    'esi_core',
     'lxml',
     'matplotlib',
     'multitaper',

--- a/environment.yml
+++ b/environment.yml
@@ -8,4 +8,5 @@ dependencies:
   - pip
   - pip:
       - git+https://github.com/uafgeotools/waveform_collection.git
+      - git+https://code.usgs.gov/ghsc/esi/esi-core.git
       - --editable .

--- a/examples/example_psd_smooth.py
+++ b/examples/example_psd_smooth.py
@@ -9,17 +9,7 @@ st = Stream.from_earthscope(
 st.detrend().taper(0.05).remove_sensitivity()
 
 # Figure 1 — No smoothing
-PSD(st).plot()
-fig1 = plt.gcf()
-fig1.axes[0].set_title('No smoothing')
-fig1.tight_layout()
-fig1.show()
+PSD(st).plot(db_lim=(20, 110))
 
 # Figure 2 — Konno–Ohmachi smoothing
-bandwidth = 40
-PSD(st).smooth(bandwidth).plot()
-fig2 = plt.gcf()
-fig2.axes[0].set_title(f'Smoothing, bandwidth = {bandwidth}')
-fig2.axes[0].set_ylim(fig1.axes[0].get_ylim())  # Easier comparison
-fig2.tight_layout()
-fig2.show()
+PSD(st).smooth(40).plot(db_lim=(20, 110))

--- a/examples/example_psd_smooth.py
+++ b/examples/example_psd_smooth.py
@@ -1,5 +1,3 @@
-import matplotlib.pyplot as plt
-
 from saul import PSD, Stream
 
 # Get and pre-process array data
@@ -8,8 +6,7 @@ st = Stream.from_earthscope(
 )
 st.detrend().taper(0.05).remove_sensitivity()
 
-# Figure 1 — No smoothing
-PSD(st).plot(db_lim=(20, 110))
-
-# Figure 2 — Konno–Ohmachi smoothing
-PSD(st).smooth(40).plot(db_lim=(20, 110))
+# Plot PSD without and with smoothing
+db_lim = 20, 110
+PSD(st).plot(db_lim=db_lim)
+PSD(st).smooth(40).plot(db_lim=db_lim)

--- a/examples/example_psd_smooth.py
+++ b/examples/example_psd_smooth.py
@@ -1,0 +1,25 @@
+import matplotlib.pyplot as plt
+
+from saul import PSD, Stream
+
+# Get and pre-process array data
+st = Stream.from_earthscope(
+    'AV', 'BAEI', 'HDF', (2023, 9, 1, 0, 5), (2023, 9, 1, 0, 15)
+)
+st.detrend().taper(0.05).remove_sensitivity()
+
+# Figure 1 — No smoothing
+PSD(st).plot()
+fig1 = plt.gcf()
+fig1.axes[0].set_title('No smoothing')
+fig1.tight_layout()
+fig1.show()
+
+# Figure 2 — Konno–Ohmachi smoothing
+bandwidth = 40
+PSD(st).smooth(bandwidth).plot()
+fig2 = plt.gcf()
+fig2.axes[0].set_title(f'Smoothing, bandwidth = {bandwidth}')
+fig2.axes[0].set_ylim(fig1.axes[0].get_ylim())  # Easier comparison
+fig2.tight_layout()
+fig2.show()

--- a/saul/spectral/__init__.py
+++ b/saul/spectral/__init__.py
@@ -6,12 +6,12 @@ import warnings
 
 with warnings.catch_warnings():
     # Ignore "SyntaxWarning: invalid escape sequence '\ '" arising from the docstring
-    # formatting in `get_ak_infra_noise()`
+    # formatting in `get_ak_infra_noise()` and `PSD.smooth()`
     warnings.simplefilter('ignore', category=SyntaxWarning)
     from saul.spectral.helpers import (
         get_ak_infra_noise,
         obspy_filter_response,
         extract_trace_filter_params,
     )
-from saul.spectral.psd import PSD
+    from saul.spectral.psd import PSD
 from saul.spectral.spectrogram import Spectrogram


### PR DESCRIPTION
This new `smooth()` method performs Konno–Ohmachi smoothing and has one required parameter, `bandwidth`. All spectra in the `PSD` object are smoothed in-place.

We use the implementation from a USGS [Engineering Seismology and Impacts repo](https://code.usgs.gov/ghsc/esi/esi-core), which is written in C for performance (note this adds a dependency).

This PR closes #27, using a slightly different approach (adding a separate method rather than tacking on to the `__init__()` as an option). This allows for ObsPy-like chained processing commands, as the new example shows:
```python
PSD(st).smooth(40).plot()
```

I think future "post-processing" approaches (such as spectral binning, etc.) make sense as methods like this one.