### PR TITLE
Modify how class docstrings are rendered

### DIFF
--- a/_doc/conf.py
+++ b/_doc/conf.py
@@ -44,7 +44,8 @@ autodoc_mock_imports = [
     'waveform_collection',
 ]
 autodoc_member_order = 'bysource'
-autoclass_content = 'init'
+autoclass_content = 'class'
+autodoc_class_signature = 'separated'
 
 todo_include_todos = True
 

--- a/saul/spectral/psd.py
+++ b/saul/spectral/psd.py
@@ -34,6 +34,9 @@ from saul.waveform.stream import Stream
 class PSD:
     """A class for calculating and plotting PSDs of one or more waveforms.
 
+    Attributes
+    ==========
+
     Attributes:
         method (str): See :meth:`__init__`
         win_dur (int or float): See :meth:`__init__`; only defined if ``method='welch'``
@@ -51,6 +54,9 @@ class PSD:
             ``[(f1, pxx_db1), (f2, pxx_db2), ...]`` given a
             :class:`~saul.waveform.stream.Stream` consisting of
             :class:`~obspy.core.trace.Trace` entries ``[tr1, tr2, ...]``
+
+    Methods
+    =======
     """
 
     def __init__(

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -25,6 +25,9 @@ from saul.waveform.stream import Stream
 class Spectrogram:
     """A class for calculating and plotting spectrograms of waveforms.
 
+    Attributes
+    ==========
+
     Attributes:
         method (str): See :meth:`__init__`
         win_dur (int or float): See :meth:`__init__`
@@ -39,6 +42,9 @@ class Spectrogram:
         spectrogram (tuple): Spectrogram (in dB) calculated from the input waveform; of
             the form ``(f, t, sxx_db)`` where ``f`` and ``t`` are 1D arrays and
             ``sxx_db`` is a 2D array with shape ``(f.size, t.size)``
+
+    Methods
+    =======
     """
 
     def __init__(


### PR DESCRIPTION
This PR modifies the Sphinx configuration so that the rendered class docstrings also show the attributes for the class. Closes #31.