### PR TITLE
Use nice cursor formatting throughout

### DIFF
--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -24,6 +24,9 @@ CYCLES_PER_WINDOW = 4
 # This file downloaded from the supplementary material of Macpherson et al. (2022)
 AK_INFRA_NOISE = Path(__file__).with_name('alaska_ambient_infrasound_noise_models.txt')
 
+# Common cursor data formatting template for frequencies and periods
+_FREQ_TEMPLATE = '{:.3g} Hz / {:.2f} s'
+
 
 def get_ak_infra_noise():
     """Returns the Alaska ambient infrasound noise models from Macpherson et al. (2022).
@@ -143,7 +146,9 @@ def obspy_filter_response(
             ax.set_yticks([0, -1, -3, -6, -10, -20])
         ax.set_xlabel('Frequency (Hz)')
         ax.set_ylabel('Gain (dB)')
-        ax.format_coord = lambda x, y: Formatter.fix_minus(f'({x:.3g} Hz, {y:.1f} dB)')
+        ax.format_coord = lambda x, y: Formatter.fix_minus(
+            f'({_FREQ_TEMPLATE.format(x, 1 / x)}, {y:.1f} dB)'
+        )
         fig.tight_layout()
         fig.show()
     return f, h_db

--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -8,6 +8,7 @@ from pathlib import Path
 
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.ticker import Formatter
 from obspy.core.util.base import _get_function_from_entry_point
 from obspy.signal.filter import lowpass_cheby_2
 from scipy.signal import freqz_zpk, iirfilter, tf2zpk
@@ -142,6 +143,7 @@ def obspy_filter_response(
             ax.set_yticks([0, -1, -3, -6, -10, -20])
         ax.set_xlabel('Frequency (Hz)')
         ax.set_ylabel('Gain (dB)')
+        ax.format_coord = lambda x, y: Formatter.fix_minus(f'({x:.3g} Hz, {y:.1f} dB)')
         fig.tight_layout()
         fig.show()
     return f, h_db

--- a/saul/spectral/psd.py
+++ b/saul/spectral/psd.py
@@ -22,6 +22,7 @@ from scipy.fft import next_fast_len
 from scipy.signal import welch
 
 from saul.spectral.helpers import (
+    _FREQ_TEMPLATE,
     CYCLES_PER_WINDOW,
     _format_power_label,
     _get_db_reference_value,
@@ -264,9 +265,8 @@ class PSD:
         ax.set_ylim(db_lim)
         ax.set_xlabel(xlabel)
         ax.set_ylabel(_format_power_label(self.db_ref_val, self.waveform_units))
-        _template = '{:.3g} Hz / {:.2f} s'
         ax.format_coord = lambda x, y: Formatter.fix_minus(
-            f'({_template.format(*(1 / x, x) if use_period else (x, 1 / x))}, {y:.1f} dB)'
+            f'({_FREQ_TEMPLATE.format(*(1 / x, x) if use_period else (x, 1 / x))}, {y:.1f} dB)'
         )
         fig.tight_layout()
         fig.show()

--- a/saul/spectral/psd.py
+++ b/saul/spectral/psd.py
@@ -10,6 +10,7 @@ import numpy as np
 from esi_core.gmprocess.waveform_processing.smoothing.konno_ohmachi import (
     konno_ohmachi_smooth,
 )
+from matplotlib.ticker import Formatter
 from multitaper import mtspec
 from obspy.signal.spectral_estimation import (
     get_idc_infra_hi_noise,
@@ -263,6 +264,10 @@ class PSD:
         ax.set_ylim(db_lim)
         ax.set_xlabel(xlabel)
         ax.set_ylabel(_format_power_label(self.db_ref_val, self.waveform_units))
+        _template = '{:.3g} Hz / {:.2f} s'
+        ax.format_coord = lambda x, y: Formatter.fix_minus(
+            f'({_template.format(*(1 / x, x) if use_period else (x, 1 / x))}, {y:.1f} dB)'
+        )
         fig.tight_layout()
         fig.show()
 

--- a/saul/spectral/response.py
+++ b/saul/spectral/response.py
@@ -8,6 +8,7 @@ import pandas as pd
 from matplotlib.ticker import Formatter
 from obspy.core.inventory import PolesZerosResponseStage
 
+from saul.spectral.helpers import _FREQ_TEMPLATE
 from saul.waveform.units import _VALID_UNIT_OPTIONS
 
 # [Hz] Minimum frequency for response computation (playing it safe here by going lower
@@ -238,6 +239,7 @@ def calculate_responses(inventory, sampling_rate=10, plot=False):
             legend = fig.legend(draggable=True)
             for text in legend.get_texts():
                 text.set_family('monospace')
+            # These secondary axes show period
             _ax1 = ax1.twiny()
             _ax2 = ax2.twiny()
             for _ax in _ax1, _ax2:
@@ -245,12 +247,11 @@ def calculate_responses(inventory, sampling_rate=10, plot=False):
                 _ax.set_xlim(1 / _MIN_FREQ, 1 / (sampling_rate / 2))
             _ax1.set_xlabel('Period (s)', labelpad=10)
             _ax2.tick_params(labeltop=False)
-            _fmt_x = lambda x: f'{1 / x:.2g} Hz / {x:.2f} s'  # Common x-axis formatter
             _ax1.format_coord = lambda x, y: Formatter.fix_minus(
-                f'({_fmt_x(x)}, {y:.1f} dB)'
+                f'({_FREQ_TEMPLATE.format(1 / x, x)}, {y:.1f} dB)'
             )
             _ax2.format_coord = lambda x, y: Formatter.fix_minus(
-                f'({_fmt_x(x)}, {y:.1f}°)'
+                f'({_FREQ_TEMPLATE.format(1 / x, x)}, {y:.1f}°)'
             )
             fig.tight_layout()
             fig.show()

--- a/saul/spectral/response.py
+++ b/saul/spectral/response.py
@@ -5,6 +5,7 @@ Calculation of sensor response and corner frequencies, with optional plotting.
 import matplotlib.pyplot as plt
 import numpy as np
 import pandas as pd
+from matplotlib.ticker import Formatter
 from obspy.core.inventory import PolesZerosResponseStage
 
 from saul.waveform.units import _VALID_UNIT_OPTIONS
@@ -244,6 +245,13 @@ def calculate_responses(inventory, sampling_rate=10, plot=False):
                 _ax.set_xlim(1 / _MIN_FREQ, 1 / (sampling_rate / 2))
             _ax1.set_xlabel('Period (s)', labelpad=10)
             _ax2.tick_params(labeltop=False)
+            _fmt_x = lambda x: f'{1 / x:.2g} Hz / {x:.2f} s'  # Common x-axis formatter
+            _ax1.format_coord = lambda x, y: Formatter.fix_minus(
+                f'({_fmt_x(x)}, {y:.1f} dB)'
+            )
+            _ax2.format_coord = lambda x, y: Formatter.fix_minus(
+                f'({_fmt_x(x)}, {y:.1f}°)'
+            )
             fig.tight_layout()
             fig.show()
 

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -9,6 +9,7 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.gridspec import GridSpec
+from matplotlib.ticker import Formatter
 from multitaper import mtspec
 from scipy.signal import spectrogram
 from stockwell import st as _st  # Avoid conflict with ObsPy `st`
@@ -201,12 +202,16 @@ class Spectrogram:
         match self.waveform_units:
             case 'pa':
                 ylabel = 'Pressure (Pa)'
+                yunit = 'Pa'
             case 'm':
                 ylabel = 'Displacement (μm)'
+                yunit = 'μm'
             case 'm/s':
                 ylabel = r'Velocity (μm s$\mathdefault{^{-1}}$)'
+                yunit = 'μm/s'
             case 'm/s**2':
                 ylabel = r'Acceleration (μm s$\mathdefault{^{-2}}$)'
+                yunit = 'μm/s²'
             case _:
                 raise ValueError(f'Invalid units: {self.waveform_units}')
         wf_ax.set_ylabel(ylabel)
@@ -249,6 +254,7 @@ class Spectrogram:
         if use_period:  # Overcome imshow() limitations by defining an axis overlay
             # Set up overlay and scale it properly
             spec_ax_overlay = spec_ax.twinx()
+            spec_ax_overlay.set_zorder(spec_ax.get_zorder() - 1)  # Place below spec
             spec_ax_overlay.set_ylim(1 / fmin, 1 / fmax)
             spec_ax_overlay.set_yscale('log')  # log_y is guaranteed to be True
             # Remove the ticks and labels from the underlying plot
@@ -325,6 +331,17 @@ class Spectrogram:
         elif max_extend and not min_extend:
             height += triangle_height
         cax.set_position([pos.xmin, ymin, pos.width, height])
+        # Cursor formatting
+        _fmt_x = lambda x: mdates.num2date(x).strftime('%Y-%m-%d %H:%M:%S UTC')
+        _template_y = '{:.3g} Hz / {:.2f} s'
+        spec_ax.format_coord = (
+            lambda x, y: f'({_fmt_x(x)}, {Formatter.fix_minus(_template_y.format(y, 1 / y))})'
+        )
+        im.format_cursor_data = lambda data: Formatter.fix_minus(f'{data:.1f} dB')
+        wf_ax.format_coord = (
+            lambda x, y: f'({_fmt_x(x)}, {Formatter.fix_minus(f'{y:.2g}')} {yunit})'
+        )
+        cax.format_coord = lambda x, y: ''  # Disable colorbar cursor info
         fig.show()
 
     def copy(self):

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -9,7 +9,6 @@ import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
 import numpy as np
 from matplotlib.gridspec import GridSpec
-from matplotlib.ticker import Formatter
 from multitaper import mtspec
 from scipy.signal import spectrogram
 from stockwell import st as _st  # Avoid conflict with ObsPy `st`
@@ -335,11 +334,11 @@ class Spectrogram:
         cax.set_position([pos.xmin, ymin, pos.width, height])
         # Cursor formatting
         spec_ax.format_coord = (
-            lambda x, y: f'({_num2date(x)}, {Formatter.fix_minus(_FREQ_TEMPLATE.format(y, 1 / y))})'
+            lambda x, y: f'({_num2date(x)}, {formatter.fix_minus(_FREQ_TEMPLATE.format(y, 1 / y))})'
         )
-        im.format_cursor_data = lambda data: Formatter.fix_minus(f'{data:.1f} dB')
+        im.format_cursor_data = lambda data: formatter.fix_minus(f'{data:.1f} dB')
         wf_ax.format_coord = (
-            lambda x, y: f'({_num2date(x)}, {Formatter.fix_minus(f'{y:.2g}')} {yunit})'
+            lambda x, y: f'({_num2date(x)}, {formatter.fix_minus(f'{y:.2g}')} {yunit})'
         )
         cax.format_coord = lambda x, y: ''  # Disable colorbar cursor info
         fig.show()

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -19,6 +19,7 @@ from saul.spectral.helpers import (
     _format_power_label,
     _get_db_reference_value,
 )
+from saul.waveform.helpers import _num2date
 from saul.waveform.stream import Stream
 from saul.waveform.units import _validate_provided_vs_inferred_units, get_waveform_units
 
@@ -332,14 +333,13 @@ class Spectrogram:
             height += triangle_height
         cax.set_position([pos.xmin, ymin, pos.width, height])
         # Cursor formatting
-        _fmt_x = lambda x: mdates.num2date(x).strftime('%Y-%m-%d %H:%M:%S UTC')
         _template_y = '{:.3g} Hz / {:.2f} s'
         spec_ax.format_coord = (
-            lambda x, y: f'({_fmt_x(x)}, {Formatter.fix_minus(_template_y.format(y, 1 / y))})'
+            lambda x, y: f'({_num2date(x)}, {Formatter.fix_minus(_template_y.format(y, 1 / y))})'
         )
         im.format_cursor_data = lambda data: Formatter.fix_minus(f'{data:.1f} dB')
         wf_ax.format_coord = (
-            lambda x, y: f'({_fmt_x(x)}, {Formatter.fix_minus(f'{y:.2g}')} {yunit})'
+            lambda x, y: f'({_num2date(x)}, {Formatter.fix_minus(f'{y:.2g}')} {yunit})'
         )
         cax.format_coord = lambda x, y: ''  # Disable colorbar cursor info
         fig.show()

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -15,6 +15,7 @@ from scipy.signal import spectrogram
 from stockwell import st as _st  # Avoid conflict with ObsPy `st`
 
 from saul.spectral.helpers import (
+    _FREQ_TEMPLATE,
     CYCLES_PER_WINDOW,
     _format_power_label,
     _get_db_reference_value,
@@ -333,9 +334,8 @@ class Spectrogram:
             height += triangle_height
         cax.set_position([pos.xmin, ymin, pos.width, height])
         # Cursor formatting
-        _template_y = '{:.3g} Hz / {:.2f} s'
         spec_ax.format_coord = (
-            lambda x, y: f'({_num2date(x)}, {Formatter.fix_minus(_template_y.format(y, 1 / y))})'
+            lambda x, y: f'({_num2date(x)}, {Formatter.fix_minus(_FREQ_TEMPLATE.format(y, 1 / y))})'
         )
         im.format_cursor_data = lambda data: Formatter.fix_minus(f'{data:.1f} dB')
         wf_ax.format_coord = (

--- a/saul/waveform/helpers.py
+++ b/saul/waveform/helpers.py
@@ -182,6 +182,8 @@ def _plot_availability_df(df, starttime, endtime):
             fontsize=plt.rcParams['font.size'] - 2,
         )
         axs[i].set_yticks([])
+        _coord_date = '%Y-%m-%d %H:%M UTC'
+        axs[i].format_coord = lambda x, y: f'{mdates.num2date(x).strftime(_coord_date)}'
         axs[i].tick_params(axis='x', bottom=False, labelbottom=False)
         for spine in axs[i].spines.values():
             spine.set_visible(False)

--- a/saul/waveform/helpers.py
+++ b/saul/waveform/helpers.py
@@ -182,8 +182,7 @@ def _plot_availability_df(df, starttime, endtime):
             fontsize=plt.rcParams['font.size'] - 2,
         )
         axs[i].set_yticks([])
-        _coord_date = '%Y-%m-%d %H:%M UTC'
-        axs[i].format_coord = lambda x, y: f'{mdates.num2date(x).strftime(_coord_date)}'
+        axs[i].format_coord = lambda x, y: _num2date(x)
         axs[i].tick_params(axis='x', bottom=False, labelbottom=False)
         for spine in axs[i].spines.values():
             spine.set_visible(False)
@@ -219,3 +218,8 @@ def _preprocess_time(starttime_or_endtime):
     elif not isinstance(starttime_or_endtime, UTCDateTime):
         raise TypeError('Time must be either a tuple or a UTCDateTime!')
     return starttime_or_endtime
+
+
+def _num2date(matplotlib_date):
+    """Convert a Matplotlib date (float) to a nicely-formatted string."""
+    return mdates.num2date(matplotlib_date).strftime('%Y-%m-%d %H:%M:%S UTC')

--- a/saul/waveform/stream.py
+++ b/saul/waveform/stream.py
@@ -269,8 +269,9 @@ class Stream(obspy.Stream):
             # Use km y-axis labels
             ax.yaxis.set_major_formatter(FuncFormatter(lambda x, _: f'{x / 1000:g}'))
             # Cursor hover labels
-            ax.format_xdata = lambda x: FuncFormatter.fix_minus(f'{x:.2f} s')
-            ax.format_ydata = lambda x: f'{x / 1000:.2f} km'
+            ax.format_coord = lambda x, y: FuncFormatter.fix_minus(
+                f'({x:.2f} s, {y / 1000:.2f} km)'
+            )
             # Label the stations
             transform = blended_transform_factory(ax.transAxes, ax.transData)
             for tr in st_plot:

--- a/saul/waveform/stream.py
+++ b/saul/waveform/stream.py
@@ -21,7 +21,7 @@ from obspy.geodetics.base import gps2dist_azimuth
 from obspy.io.kml.core import _rgba_tuple_to_kml_color_code
 from waveform_collection import gather_waveforms, read_local
 
-from saul.waveform.helpers import _preprocess_time
+from saul.waveform.helpers import _num2date, _preprocess_time
 
 
 class Stream(obspy.Stream):
@@ -323,10 +323,9 @@ class Stream(obspy.Stream):
             if 'wavespeed' in kwargs:
                 print('Ignoring `wavespeed` kwarg!')  # Can't use this kwarg here
             fig = super().plot(*args, **kwargs)
-            _fmt_x = lambda x: mdates.num2date(x).strftime('%Y-%m-%d %H:%M:%S UTC')
             for ax in fig.axes:
                 ax.format_coord = (
-                    lambda x, y: f'({_fmt_x(x)}, {FuncFormatter.fix_minus(f'{y:.2g}')} unknown units)'
+                    lambda x, y: f'({_num2date(x)}, {FuncFormatter.fix_minus(f'{y:.2g}')} unknown units)'
                 )
             return fig
 

--- a/saul/waveform/stream.py
+++ b/saul/waveform/stream.py
@@ -322,7 +322,13 @@ class Stream(obspy.Stream):
         else:
             if 'wavespeed' in kwargs:
                 print('Ignoring `wavespeed` kwarg!')  # Can't use this kwarg here
-            return super().plot(*args, **kwargs)
+            fig = super().plot(*args, **kwargs)
+            _fmt_x = lambda x: mdates.num2date(x).strftime('%Y-%m-%d %H:%M:%S UTC')
+            for ax in fig.axes:
+                ax.format_coord = (
+                    lambda x, y: f'({_fmt_x(x)}, {FuncFormatter.fix_minus(f'{y:.2g}')} unknown units)'
+                )
+            return fig
 
     @staticmethod
     def _time_tuple(t):


### PR DESCRIPTION
This PR makes tweaks to every SAUL plotting method/function so that the cursor in the interactive plotting window shows a friendly output that's useful for interactive snooping of data.

The GIF below shows how the new output compares to the old for the spectrogram plot. Note info displayed in lower-right-hand corner:
<img width="1624" height="1352" alt="ezgif com-animated-gif-maker" src="https://github.com/user-attachments/assets/b4c47e29-bd2f-419d-aabd-0390c7b38bfe" />
