### PR TITLE
Add support for `units=None` for unknown units

### DIFF
--- a/saul/spectral/helpers.py
+++ b/saul/spectral/helpers.py
@@ -218,6 +218,9 @@ def _format_power_label(db_ref_val, waveform_units):
         case 'm/s**2':
             assert db_ref_val == REFERENCE_SEISMIC == 1
             return rf'Power (dB rel. {db_ref_val:g} [m s$\mathdefault{{^{{-2}}}}$]$\mathdefault{{^2}}$ Hz$\mathdefault{{^{{-1}}}}$)'
+        case None:
+            assert db_ref_val is None  # Reference value is meaningless w/o units!
+            return r'Power (dB rel. max. Hz$\mathdefault{{^{{-1}}}}$)'
         case _:
             raise ValueError(f'Invalid units: {waveform_units}')
 

--- a/saul/spectral/psd.py
+++ b/saul/spectral/psd.py
@@ -81,8 +81,7 @@ class PSD:
 
         Args:
             tr_or_st (:class:`~obspy.core.trace.Trace` or :class:`~saul.waveform.stream.Stream`):
-                Input waveforms (response is expected to be removed; see ``units``
-                argument)
+                Input waveforms
             method (str): Either ``'welch'`` **[W]** or ``'multitaper'`` **[M]**
             win_dur (int or float): **[W]** Segment length in seconds. This usually must
                 be tweaked to obtain the cleanest-looking plot and to ensure that the
@@ -90,9 +89,10 @@ class PSD:
             time_bandwidth_product (float): **[M]** Time-bandwidth product
             number_of_tapers (int): **[M]** Number of tapers to use
             units (str): Units of the input waveforms; either ``'infer'`` to guess from
-                input response information or a string explicitly defining the units
-                (see ``_VALID_UNIT_OPTIONS`` in :mod:`saul.waveform.units` for supported
-                options) — all input waveforms must have the same units!
+                input response information, a string explicitly defining the units (see
+                ``_VALID_UNIT_OPTIONS`` in :mod:`saul.waveform.units` for supported
+                options), or ``None`` for unknown units (e.g., counts) — all input
+                waveforms must have the same units!
         """
         # Pre-processing and checks
         assert method in [
@@ -123,6 +123,8 @@ class PSD:
         self.waveform_units = _validate_provided_vs_inferred_units(
             units, inferred_units_unique[0], self.data_kind
         )
+        if self.waveform_units is None:
+            self.db_ref_val = None  # Reference value is meaningless w/o units!
 
         # KEY: Calculate PSD (in dB relative to self.db_ref_val)
         self.psd = []
@@ -143,9 +145,15 @@ class PSD:
                 f, pxx = mtspec.rspec()
                 f, pxx = f.squeeze(), pxx.squeeze()
             f, pxx = f[1:], pxx[1:]  # Remove DC component
-            # Convert to dB [dB rel. (db_ref_val <db_ref_val_unit>)^2 Hz^-1]
-            pxx_db = 10 * np.log10(pxx / (self.db_ref_val**2))
-            self.psd.append((f, pxx_db))
+            self.psd.append((f, pxx))
+        # Convert to dB [dB rel. (db_ref_val <db_ref_val_unit>)^2 Hz^-1]
+        if self.db_ref_val is None:
+            denominator = max([pxx.max() for _, pxx in self.psd])  # 0 dB for global max
+        else:
+            denominator = self.db_ref_val**2
+        for i, (f, pxx) in enumerate(self.psd):
+            pxx_db = 10 * np.log10(pxx / denominator)
+            self.psd[i] = (f, pxx_db)
 
     def plot(
         self,
@@ -180,6 +188,9 @@ class PSD:
         if log_x:
             ax.set_xscale('log')
         if show_noise_models:
+            if self.waveform_units is None:
+                msg = 'Can\'t show noise models if waveform units are unknown!'
+                raise ValueError(msg)
             match self.data_kind:
                 case 'infrasound':
                     if infra_noise_model == 'ak':

--- a/saul/spectral/psd.py
+++ b/saul/spectral/psd.py
@@ -50,8 +50,9 @@ class PSD:
             :class:`~saul.waveform.stream.Stream`)
         data_kind (str): Input waveform data kind; e.g., ``'infrasound'`` or
             ``'seismic'`` (inferred from channel code)
-        db_ref_val (int or float): dB reference value for PSD (data kind dependent)
-        waveform_units (str): Units of the input waveforms
+        db_ref_val (int, float, or None): dB reference value for PSD (data kind
+            dependent)
+        waveform_units (str or None): Units of the input waveforms
         psd (list): List of PSDs (in dB) calculated from input waveforms; of the form
             ``[(f1, pxx_db1), (f2, pxx_db2), ...]`` given a
             :class:`~saul.waveform.stream.Stream` consisting of
@@ -88,11 +89,11 @@ class PSD:
                 longest-period signals of interest are included
             time_bandwidth_product (float): **[M]** Time-bandwidth product
             number_of_tapers (int): **[M]** Number of tapers to use
-            units (str): Units of the input waveforms; either ``'infer'`` to guess from
-                input response information, a string explicitly defining the units (see
-                ``_VALID_UNIT_OPTIONS`` in :mod:`saul.waveform.units` for supported
-                options), or ``None`` for unknown units (e.g., counts) — all input
-                waveforms must have the same units!
+            units (str or None): Units of the input waveforms; either ``'infer'`` to
+                guess from input response information, a string explicitly defining the
+                units (see ``_VALID_UNIT_OPTIONS`` in :mod:`saul.waveform.units` for
+                supported options), or ``None`` for unknown units (e.g., counts) — all
+                input waveforms must have the same units!
         """
         # Pre-processing and checks
         assert method in [

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -79,8 +79,7 @@ class Spectrogram:
 
         Args:
             tr_or_st (:class:`~obspy.core.trace.Trace` or :class:`~saul.waveform.stream.Stream`):
-                Input waveform (response is expected to be removed; see ``units``
-                argument)
+                Input waveform
             method (str): Either ``'scipy'`` **[P]**, ``'multitaper'`` **[M]**, or
                 ``'s_transform'`` **[S]**
             win_dur (int or float): **[P]** **[M]** Segment length in seconds. This
@@ -97,9 +96,9 @@ class Spectrogram:
                 downsampled before the :math:`S` transform is computed (this saves
                 computation time and memory)
             units (str): Units of the input waveform; either ``'infer'`` to guess from
-                input response information or a string explicitly defining the units
+                input response information, a string explicitly defining the units
                 (see ``_VALID_UNIT_OPTIONS`` in :mod:`saul.waveform.units` for supported
-                options)
+                options), or ``None`` for unknown units (e.g., counts)
         """
         # Pre-processing and checks
         msg = 'Method must be either \'scipy\', \'multitaper\', or \'s_transform\''
@@ -127,6 +126,8 @@ class Spectrogram:
         self.waveform_units = _validate_provided_vs_inferred_units(
             units, inferred_units, self.data_kind
         )
+        if self.waveform_units is None:
+            self.db_ref_val = None  # Reference value is meaningless w/o units!
 
         # KEY: Calculate spectrogram (in dB relative to self.db_ref_val)
         match self.method:
@@ -170,7 +171,11 @@ class Spectrogram:
                 sxx = np.abs(_sxx) ** 2  # TODO: Convert to power? What about density?
         f, sxx = f[1:], sxx[1:, :]  # Remove DC component
         # Convert to dB [dB rel. (db_ref_val <db_ref_val_unit>)^2 Hz^-1]
-        sxx_db = 10 * np.log10(sxx / (self.db_ref_val**2))
+        if self.db_ref_val is None:
+            denominator = sxx.max()  # 0 dB is max
+        else:
+            denominator = self.db_ref_val**2
+        sxx_db = 10 * np.log10(sxx / denominator)
         self.spectrogram = (f, t, sxx_db)
 
     def plot(
@@ -196,7 +201,10 @@ class Spectrogram:
         spec_ax = fig.add_subplot(gs[0, 0])
         wf_ax = fig.add_subplot(gs[1, 0], sharex=spec_ax)  # Common time axis
         cax = fig.add_subplot(gs[0, 1])
-        rescale = 1e6 if self.data_kind == 'seismic' else 1  # Use μ prefix for seismic
+        if self.data_kind == 'seismic' and self.waveform_units is not None:
+            rescale = 1e6  # Use μ prefix for seismic, unless we have unknown units
+        else:
+            rescale = 1
         wf_ax.plot(
             self.tr.times('matplotlib'), self.tr.data * rescale, 'black', linewidth=0.5
         )
@@ -213,6 +221,9 @@ class Spectrogram:
             case 'm/s**2':
                 ylabel = r'Acceleration (μm s$\mathdefault{^{-2}}$)'
                 yunit = 'μm/s²'
+            case None:
+                ylabel = 'Amplitude'
+                yunit = 'unknown units'
             case _:
                 raise ValueError(f'Invalid units: {self.waveform_units}')
         wf_ax.set_ylabel(ylabel)

--- a/saul/spectral/spectrogram.py
+++ b/saul/spectral/spectrogram.py
@@ -44,8 +44,9 @@ class Spectrogram:
         tr (:class:`~obspy.core.trace.Trace`): Input waveform
         data_kind (str): Input waveform data kind; e.g., ``'infrasound'`` or
             ``'seismic'`` (inferred from channel code)
-        db_ref_val (int or float): dB reference value for PSD (data kind dependent)
-        waveform_units (str): Units of the input waveform
+        db_ref_val (int, float, or None): dB reference value for PSD (data kind
+            dependent)
+        waveform_units (str or None): Units of the input waveform
         spectrogram (tuple): Spectrogram (in dB) calculated from the input waveform; of
             the form ``(f, t, sxx_db)`` where ``f`` and ``t`` are 1D arrays and
             ``sxx_db`` is a 2D array with shape ``(f.size, t.size)``
@@ -95,10 +96,10 @@ class Spectrogram:
                 input signal has a sampling rate higher than this, it will be
                 downsampled before the :math:`S` transform is computed (this saves
                 computation time and memory)
-            units (str): Units of the input waveform; either ``'infer'`` to guess from
-                input response information, a string explicitly defining the units
-                (see ``_VALID_UNIT_OPTIONS`` in :mod:`saul.waveform.units` for supported
-                options), or ``None`` for unknown units (e.g., counts)
+            units (str or None): Units of the input waveform; either ``'infer'`` to
+                guess from input response information, a string explicitly defining the
+                units (see ``_VALID_UNIT_OPTIONS`` in :mod:`saul.waveform.units` for
+                supported options), or ``None`` for unknown units (e.g., counts)
         """
         # Pre-processing and checks
         msg = 'Method must be either \'scipy\', \'multitaper\', or \'s_transform\''

--- a/saul/waveform/units.py
+++ b/saul/waveform/units.py
@@ -156,11 +156,14 @@ def _validate_provided_vs_inferred_units(
     provided_units: str, inferred_units: str | None, data_kind: str
 ) -> str:
     """Validate user-provided units against inferred units."""
-    if provided_units == 'infer':
+    if provided_units is None:
+        return None  # Pass through since there are no units to check!
+    elif provided_units == 'infer':
         if not inferred_units:
             msg = (
                 'Could not infer units; please provide them explicitly!'
-                f'\nChoose one of {_VALID_UNIT_OPTIONS}'
+                f'\n\tChoose one of {_VALID_UNIT_OPTIONS},'
+                '\n\tor specify None if units are unknown (e.g., counts).'
             )
             raise ValueError(msg)
         else:

--- a/saul/waveform/units.py
+++ b/saul/waveform/units.py
@@ -158,7 +158,11 @@ def _validate_provided_vs_inferred_units(
     """Validate user-provided units against inferred units."""
     if provided_units == 'infer':
         if not inferred_units:
-            raise ValueError('Could not infer units; please provide them explicitly!')
+            msg = (
+                'Could not infer units; please provide them explicitly!'
+                f'\nChoose one of {_VALID_UNIT_OPTIONS}'
+            )
+            raise ValueError(msg)
         else:
             validated_units = inferred_units
     else:  # Use explicitly provided units

--- a/saul/waveform/units.py
+++ b/saul/waveform/units.py
@@ -153,8 +153,8 @@ def get_waveform_units(tr: Trace) -> Tuple[str, str | None]:
 
 
 def _validate_provided_vs_inferred_units(
-    provided_units: str, inferred_units: str | None, data_kind: str
-) -> str:
+    provided_units: str | None, inferred_units: str | None, data_kind: str
+) -> str | None:
     """Validate user-provided units against inferred units."""
     if provided_units is None:
         return None  # Pass through since there are no units to check!


### PR DESCRIPTION
This PR adds a `units=None` option for PSDs / spectrograms. This allows folks to use "raw" data that may be in, e.g., integer counts. Closes #41.